### PR TITLE
Add injection timing metrics for hot reload performance tracking

### DIFF
--- a/App/InjectionNext/NextCompiler.swift
+++ b/App/InjectionNext/NextCompiler.swift
@@ -24,7 +24,7 @@ struct InjectionMetricsTracker: Codable {
     var totalTimeMs: Double = 0
     var sourcePath: String
     var success: Bool = false
-    var notificationName: String = "INJECTION_METRICS_NOTIFICATION"
+    var notificationName: String = INJECTION_METRICS_NOTIFICATION
     let startTime: Double
 
     init(sourcePath: String) {

--- a/Sources/InjectionNext/InjectionNext.swift
+++ b/Sources/InjectionNext/InjectionNext.swift
@@ -148,6 +148,19 @@ open class InjectionNext: SimpleSocket {
                 let dylib = NSTemporaryDirectory() + dylibName
                 try! data.write(to: URL(fileURLWithPath: dylib))
                 injectAndSweep(dylib)
+            case .metrics:
+                guard let metricsJSON = readString() else {
+                    return error("Unable to read metrics JSON")
+                }
+                if let data = metricsJSON.data(using: .utf8),
+                   let metricsDict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let notificationName = metricsDict["notification_name"] as? String {
+                    NotificationCenter.default.post(
+                        name: NSNotification.Name(notificationName),
+                        object: nil,
+                        userInfo: metricsDict
+                    )
+                }
             case .EOF:
                 return
             default:

--- a/Sources/InjectionNextC/include/InjectionClient.h
+++ b/Sources/InjectionNextC/include/InjectionClient.h
@@ -40,6 +40,7 @@ typedef NS_ENUM(int, InjectionCommand) {
     InjectionInject,
     InjectionXcodePath,
     InjectionSendFile,
+    InjectionMetrics,
 
     InjectionInvalid = 1000,
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive timing metrics to InjectionNext that allow client apps to track hot reload performance. The metrics are sent from the server to the client app via a new notification.

## Metrics Tracked

The implementation tracks the following timing metrics (all in milliseconds):

- **Processing Time**: Time to find target and prepare compilation command before compilation starts
- **Compilation Time**: Time spent compiling the modified source file
- **Linking Time**: Time spent linking the compiled object into a dynamic library
- **Total Time**: End-to-end injection time from start to finish

Additional metadata:
- **Files Modified Count**: Number of files modified (currently always 1)
- **Source Path**: Path to the modified source file
- **Success**: Boolean indicating if injection succeeded
- **Timestamp**: Unix timestamp when metrics were captured

## Implementation Details

### Protocol Extension
- Added `InjectionMetrics` command type to `InjectionCommand` enum in `InjectionClient.h`

### Server Side (App/InjectionNext/)
- **InjectionMetricsTracker**: New class to track all timing data
- **NextCompiler.swift**: 
  - Modified `inject()` to create metrics tracker and send metrics on completion
  - Modified `recompile()` to track processing and compilation time
  - Modified `link()` to return linking time as tuple `(String, Double)?`
  - Modified `prepare()` to capture linking time from link method
- **InjectionServer.swift**: Added `sendMetrics()` method to send JSON metrics to client

### Client Side (Sources/InjectionNext/)
- **InjectionNext.swift**: Added handling for `.metrics` command case
  - Parses JSON metrics string
  - Posts `INJECTION_METRICS_NOTIFICATION` with metrics in userInfo

## Usage

Client apps can observe the notification to track hot reload performance:

```swift
NotificationCenter.default.addObserver(
    forName: NSNotification.Name("INJECTION_METRICS_NOTIFICATION"),
    object: nil,
    queue: .main
) { notification in
    if let metrics = notification.userInfo {
        print("Processing: \(metrics["processing_time_ms"] ?? 0)ms")
        print("Compilation: \(metrics["compilation_time_ms"] ?? 0)ms")
        print("Linking: \(metrics["linking_time_ms"] ?? 0)ms")
        print("Total: \(metrics["total_time_ms"] ?? 0)ms")
        print("Success: \(metrics["success"] ?? false)")
    }
}
```

## JSON Format

Metrics are sent as JSON:

```json
{
  "success": true,
  "processing_time_ms": 150.0,
  "compilation_time_ms": 2800.0,
  "linking_time_ms": 700.0,
  "total_time_ms": 3650.0,
  "source_path": "/path/to/modified/file.swift",
  "timestamp": 1234567890.0
}
```

## Backward Compatibility

- Metrics are sent for both successful and failed injections
- Existing apps will continue to work without any changes
- Apps that don't observe the notification will simply ignore the metrics

## Testing

- ✅ Build passes with `swift build`
- ✅ No breaking changes to existing functionality
- ✅ Metrics sent on both success and failure paths