### PR TITLE
Stop file processing when git repository is locked

### DIFF
--- a/App/InjectionNext/InjectionServer.swift
+++ b/App/InjectionNext/InjectionServer.swift
@@ -126,7 +126,8 @@ class InjectionServer: SimpleSocket {
                     // Reset repository locked state on app reconnect (relaunch)
                     if InjectionHybrid.isRepositoryLocked {
                         InjectionHybrid.isRepositoryLocked = false
-                        log("Repository lock cleared - injection resumed")
+                        InjectionHybrid.gitLockPath = nil
+                        self.log("Repository lock cleared - injection resumed")
                     }
                 }
                 AppDelegate.ui.setMenuIcon(.ok)


### PR DESCRIPTION
Adds git lock detection to prevent unnecessary processing during branch switches, merges, and rebases. When a git lock is detected:

- Sets isRepositoryLocked flag to stop all file processing
- Clears pending files queue to prevent stale injections
- Notifies user that rebuild is required to resume
- Automatically resets when app reconnects (after rebuild)

This prevents injection attempts when the app state no longer matches the source code, improving reliability during git operations.