### PR TITLE
Add env var to hide alert to quit Xcode

### DIFF
--- a/App/InjectionNext/AppDelegate.swift
+++ b/App/InjectionNext/AppDelegate.swift
@@ -105,7 +105,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 Defaults.xcodeDefault = xcodePath
             }
             selectXcodeItem.toolTip = Defaults.xcodePath
-            if updatePatchUnpatch() == .unpatched {
+            if updatePatchUnpatch() == .unpatched
+                && ProcessInfo.processInfo.environment["INJECTION_HIDE_XCODE_ALERT"] != "1" {
                 InjectionServer.alert("""
                     Please quit Xcode and
                     use this app to launch it


### PR DESCRIPTION
This alert can be confusing for Bazel-based use cases (and/or for any other usage of the file watcher mode.) Allow suppressing it via an env var.

Use case: we spawn InjectionNext programmatically and auto-configure it with Bazel by setting `SIMCTL_CHILD_INJECTION_PROJECT_ROOT` + `SIMCTL_CHILD_INJECTION_BAZEL_TARGET`. This is the last piece remaining (paired with https://github.com/johnno1962/InjectionLite/pull/21) to allow InjectionNext to work 100% transparently with no user interaction!