### PR TITLE
Filter whole-module-optimization flags from compiler arguments

### DIFF
--- a/App/InjectionNext/FrontendServer.swift
+++ b/App/InjectionNext/FrontendServer.swift
@@ -231,7 +231,7 @@ class FrontendServer: SimpleSocket {
                 } else if arg[Reloader.optionsToRemove] {
                     _ = next()
                 } else if !arg[
-                    "-validate-clang-modules-once|-frontend-parseable-output"] {
+                    "-validate-clang-modules-once|-frontend-parseable-output|-whole-module-optimization|-internalize-at-link|-no-serialize-debugging-options"] {
                     args.append(arg)
                 }
             }

--- a/App/InjectionNext/NextCompiler.swift
+++ b/App/InjectionNext/NextCompiler.swift
@@ -288,7 +288,12 @@ class NextCompiler {
              "-plugin-path", toolchain+"/usr/lib/swift/host/plugins",
              "-plugin-path", toolchain+"/usr/local/lib/swift/host/plugins"] :
             ["-c", source, "-Xclang", "-fno-validate-pch"]) + baseOptionsToAdd
-        var arguments = stored.arguments
+        let wmoFlags: Set<String> = [
+            "-whole-module-optimization",
+            "-internalize-at-link",
+            "-no-serialize-debugging-options"
+        ]
+        var arguments = stored.arguments.filter { !wmoFlags.contains($0) }
         if let target = InjectionServer.currentClient?.arch, target != "arm64" {
             // Simulator running in Rosetta.
             for i in 0..<arguments.count {


### PR DESCRIPTION
## Problem

When a project is built with **Whole Module Optimization** (WMO) enabled, injection fails because the captured compilation commands contain flags that are incompatible with single-file recompilation:

- `-whole-module-optimization`
- `-internalize-at-link`
- `-no-serialize-debugging-options`

These flags cause the recompile step to fail since injection needs to recompile individual files, not the whole module.

## Solution

Strip WMO-related flags in two places:

1. **`CompilationArgParser.process(arg:next:)`** (`FrontendServer.swift`) — filters them out during initial command capture from SourceKit / `swift-frontend.sh`, so they're never stored.

2. **`NextCompiler.recompile(source:platform:)`** (`NextCompiler.swift`) — filters them from stored arguments before recompilation, catching any commands that were cached before the parser fix.

This is the same approach already used for `-validate-clang-modules-once` and `-frontend-parseable-output`.

## Testing

- Tested with a large Bazel-based iOS project that uses WMO in its build configuration
- Verified injection succeeds for Swift files after the flags are stripped
- No impact on projects that don't use WMO (flags simply aren't present)

Made with [Cursor](https://cursor.com)