### PR TITLE
Fix Bazel hot-reload: handle .swift-suffixed include paths and stale -o flags

### DIFF
--- a/App/InjectionNext/FrontendServer.swift
+++ b/App/InjectionNext/FrontendServer.swift
@@ -225,7 +225,10 @@ class FrontendServer: SimpleSocket {
                         Unhider.packageFrameworks = arg+"/PackageFrameworks"
                     }
                 }
-                if arg.hasSuffix(".swift") && args.last != "-F" {
+                let pathArgFlags: Set<String> = ["-F", "-I", "-iquote", "-isystem"]
+                let isPathArgValue = pathArgFlags.contains(args.last ?? "")
+                    || arg.hasPrefix("-I") || arg.hasPrefix("-F")
+                if arg.hasSuffix(".swift") && !isPathArgValue {
                     swiftFiles += arg+"\n"
                     swiftFileCount += 1
                 } else if arg[Reloader.optionsToRemove] {

--- a/App/InjectionNext/Info.plist
+++ b/App/InjectionNext/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>14069</string>
+	<string>14078</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/App/InjectionNext/NextCompiler.swift
+++ b/App/InjectionNext/NextCompiler.swift
@@ -51,6 +51,8 @@ class NextCompiler {
     static var lastError: String?, lastSource: String?
 
     let name: String
+    /// Base for temporary files
+    let tmpbase = "/tmp/injectionNext"
     /// Injection pending if information was not available
     var pendingSource: String?
     /// Information for compiling a file per source file.
@@ -256,9 +258,9 @@ class NextCompiler {
         }
 
         let uniqueObject = InjectionServer.currentClient?.injectionNumber ?? 0
-        let object = Reloader.tmpbase+"_\(uniqueObject).o"
+        let object = tmpbase+"_\(uniqueObject).o"
         let isSwift = source.hasSuffix(".swift")
-        let filesfile = Reloader.tmpbase+".filelist"
+        let filesfile = tmpbase+".filelist"
 
         unlink(object)
         unlink(filesfile)
@@ -286,7 +288,18 @@ class NextCompiler {
              "-plugin-path", toolchain+"/usr/lib/swift/host/plugins",
              "-plugin-path", toolchain+"/usr/local/lib/swift/host/plugins"] :
             ["-c", source, "-Xclang", "-fno-validate-pch"]) + baseOptionsToAdd
-        var arguments = stored.arguments
+        let wmoFlags: Set<String> = [
+            "-whole-module-optimization",
+            "-internalize-at-link",
+            "-no-serialize-debugging-options"
+        ]
+        var arguments = [String]()
+        var skipNext = false
+        for arg in stored.arguments where !wmoFlags.contains(arg) {
+            if skipNext { skipNext = false; continue }
+            if arg == "-o" { skipNext = true; continue }
+            arguments.append(arg)
+        }
         if let target = InjectionServer.currentClient?.arch, target != "arm64" {
             // Simulator running in Rosetta.
             for i in 0..<arguments.count {

--- a/BAZEL.md
+++ b/BAZEL.md
@@ -12,12 +12,12 @@ The system uses a two-tier approach: first attempting optimized queries using di
 
 Bazel integration requires either `bazel` or `/opt/homebrew/bin/bazelisk` to be available in your system PATH.
 
-### ⚠️ rules_xcodeproj Limitation
+### rules_xcodeproj Support
 
-**Important**: Currently, Bazel queries and commands cannot be executed from within the rules_xcodeproj-generated Xcode project environment. This means:
+When a project uses `rules_xcodeproj`, Xcode builds artifacts in a separate output base at `<outputBase>/rules_xcodeproj.noindex/build_output_base/` rather than the main Bazel output base. InjectionNext automatically detects this and:
 
-- If you run your app from Xcode using a rules_xcodeproj-generated project and modify a file, **hot reloading will not work** because the app runs through a different execution route that doesn't provide access to Bazel tooling
-- **Workaround**: Run your app directly from the terminal using `bazel run` instead of launching from Xcode to enable hot reloading functionality
-- This limitation only affects rules_xcodeproj workflows - standard Bazel development workflows are fully supported
+- Resolves `bazel-out/` paths to the rules_xcodeproj output base
+- Maps aquery configuration hashes (e.g. `ios_sim_arm64-fastbuild-*`) to the corresponding rules_xcodeproj configs (e.g. `ios_sim_arm64-dbg-*`)
+- Uses the rules_xcodeproj exec root as the working directory for recompilation
 
-We're working on addressing this limitation in future releases.
+This is transparent — hot reloading works the same whether you build via `bazel run` or from Xcode with a rules_xcodeproj-generated project.


### PR DESCRIPTION
## Summary

Fixes three issues that prevent hot-reload injection from working in Bazel monorepos (particularly with `rules_xcodeproj`):

### 1. `.swift`-suffixed include paths misclassified as source files

**`FrontendServer.swift` — `CompilationArgParser.process`**

SPM packages with names ending in `.swift` (e.g. `ulid.swift`) produce include paths like `-I/path/to/swiftpkg_ulid.swift`. The arg parser checks `hasSuffix(".swift")` and only excluded `-F` as a predecessor flag. This caused the path to be added to `swiftFiles` instead of `args`, breaking compilation.

**Fix:** Expanded the guard to check for `-I`, `-iquote`, `-isystem` in addition to `-F`. Also handles the concatenated form (`-I/path/...`) where the flag and path are a single token, by checking `hasPrefix("-I")` and `hasPrefix("-F")`.

### 2. Stale `-o` flag from original build causes object file to be written to wrong path

**`NextCompiler.swift` — `recompile`**

The stored compilation arguments contain the original `-o /path/to/bazel/output.o` from the Bazel build. `NextCompiler` appends its own `-o eval1.o`, but `swift-frontend` uses the **first** `-o` it encounters, so the `.o` file is written to the Bazel path instead of the expected temp path. The linker then fails with `no such file or directory: eval1.o`.

**Fix:** Filter out any existing `-o <value>` pair from `stored.arguments` before appending the new output path. Uses a `skipNext` flag to consume the value token after `-o`.

Also re-adds WMO flag filtering (`-whole-module-optimization`, `-internalize-at-link`, `-no-serialize-debugging-options`) that was removed in the Xcode26.3 branch — these flags prevent single-file recompilation.

### 3. Restored local `tmpbase` for `NextCompiler`

The Xcode26.3 branch switched `NextCompiler` to use `Reloader.tmpbase` (which resolves to `NSTemporaryDirectory() + "eval\(N)"`), but the `link()` method in `NextCompiler` expects the object at `/tmp/injectionNext_N.o`. Restored the local `let tmpbase = "/tmp/injectionNext"` to keep the two paths consistent.

### 4. Updated BAZEL.md documentation

Replaced the "rules_xcodeproj Limitation" warning (which stated hot-reload doesn't work with rules_xcodeproj) with documentation explaining how InjectionNext now handles `rules_xcodeproj` output bases.

## Impact on other Bazel implementations

These changes are **backwards-compatible** and should not break existing Bazel workflows:

- The `-I`/`-F` prefix check in `FrontendServer` is strictly additive — it only prevents misclassification of paths that were previously incorrectly treated as source files. Standard `.swift` source files are unaffected since they don't start with `-I` or `-F`.
- The `-o` stripping in `NextCompiler` only affects the stored args before the injection-specific `-o` is appended. The original build is never modified.
- WMO flag filtering was already present on the `main` branch — this just restores it to `Xcode26.3`.
- The `tmpbase` change only affects `NextCompiler`'s internal temp file paths and doesn't touch any Bazel build artifacts.

## Testing

Tested on Bazel project with `rules_xcodeproj`:
- Compilation args correctly exclude `ulid.swift` include paths from source file list
- Object file written to correct temp path
- Linking proceeds with correct `.o` path


Related Pull Request: https://github.com/johnno1962/InjectionLite/pull/23
Made with [Cursor](https://cursor.com)