### PR TITLE
fix(app): prompt to quit pre-existing Xcode before attaching MonitorXcode

### DIFF
--- a/App/InjectionNext/AppDelegate.swift
+++ b/App/InjectionNext/AppDelegate.swift
@@ -153,8 +153,63 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Actions
 
     @IBAction func runXcode(_ sender: Any) {
-        if MonitorXcode.runningXcode == nil {
-            _ = MonitorXcode()
+        guard MonitorXcode.runningXcode == nil else { return }
+
+        // If an Xcode is already running but wasn't launched by us
+        // (no RUNNING_VIA_INJECTION_NEXT=1 env marker), `Popen(... Xcode ...)`
+        // would spawn a shell child that exits immediately — macOS just
+        // activates the existing app. That leaves us with no SourceKit
+        // log stream, so the first client connect flips the menu icon
+        // to .error (red). Ask the user to quit it so we can relaunch
+        // it under our control with SOURCEKIT_LOGGING=1.
+        if let external = externalRunningXcode() {
+            guard confirmQuitExternalXcode() else { return }
+            external.terminate()
+            waitForXcodeToExit(external)
+        }
+
+        _ = MonitorXcode()
+    }
+
+    /// Returns a running Xcode that we did *not* spawn, or nil if either
+    /// no Xcode is running or the running one was launched by us.
+    func externalRunningXcode() -> NSRunningApplication? {
+        guard let xcode = NSRunningApplication
+            .runningApplications(withBundleIdentifier: "com.apple.dt.Xcode")
+            .first else { return nil }
+        // `ps eww -p <pid>` prints env vars of processes owned by the
+        // current user, which is exactly what we need here.
+        let pid = xcode.processIdentifier
+        if let env = Popen(cmd: "ps eww -p \(pid) -o command= 2>/dev/null")?
+            .readAll(), env.contains("RUNNING_VIA_INJECTION_NEXT=1") {
+            return nil
+        }
+        return xcode
+    }
+
+    /// Prompts the user to quit the externally-launched Xcode so we can
+    /// relaunch it with SourceKit logging enabled. Returns true on confirm.
+    func confirmQuitExternalXcode() -> Bool {
+        let alert = NSAlert()
+        alert.messageText = "Quit and relaunch Xcode?"
+        alert.informativeText = """
+            Xcode is already running but was not launched by InjectionNext. \
+            To parse its SourceKit logs (needed for compile-arg capture), \
+            InjectionNext needs to quit it and relaunch it with \
+            SOURCEKIT_LOGGING=1. Unsaved work will prompt you in Xcode.
+            """
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Quit & Relaunch")
+        alert.addButton(withTitle: "Cancel")
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+
+    /// Polls until the given running app reports terminated, up to ~15s.
+    func waitForXcodeToExit(_ app: NSRunningApplication) {
+        let deadline = Date().addingTimeInterval(15)
+        while !app.isTerminated && Date() < deadline {
+            RunLoop.current.run(mode: .default,
+                                before: Date().addingTimeInterval(0.1))
         }
     }
 

--- a/TODO.md
+++ b/TODO.md
@@ -13,19 +13,19 @@ Tracking the path from today's `2.0_overhaul` to a tagged `2.0.0`.
   - `UI: LogManager + ConsoleView` — central `ObservableObject` logger with ring buffer, dedupe, uncaught-exception / fatal-signal capture, stdout/stderr hijack mirrored to the real fds; `Window("console")` scene; `LogBuffer` becomes a typealias of `LogManager` for back-compat.
 - [x] **Swift 6 / strict-concurrency audit** — nothing in the ported UI requires Swift 6; package/target language mode stays Swift 5.
 - [x] **Device Testing toggle** — split from `devicesEnabled`. Gates linking of `deviceLibraries` (XCTest + helpers) into the injection dylib. Prevents `Library not loaded: @rpath/XCTest.framework/XCTest` crashes on apps that don't ship `copy_bundle.sh`.
+- [x] **Bump version to 2.0.0** — `MARKETING_VERSION`; tag after upstream merge.
+- [x] **Re-sync submodules against latest heads** — after upstream merges, run `git submodule update --init --recursive` and bump pins in a dedicated commit.
+- [x] **Fix red internal-Xcode icon when launching Xcode from the app (non log-parsing path)** — detect a pre-existing user-launched Xcode (no `RUNNING_VIA_INJECTION_NEXT=1` env marker), prompt to quit-and-relaunch so `Popen(... SOURCEKIT_LOGGING=1 ... Xcode ...)` actually owns the process and the log tap stays open. Fixes the red icon that came from the shell child exiting instantly against a single-instanced Xcode.
+
+## Current branch
+
+`maatheusgois-dd/fix-external-xcode-icon` off upstream `2.0_overhaul`.
 
 ## Next
 
-- [ ] **Bump version to 2.0.0** — `MARKETING_VERSION`; tag after upstream merge.
-- [ ] **Fix red internal-Xcode icon when launching Xcode from the app (non log-parsing path)** — currently stays red until a compile event flips it; need to flip to idle/green once the `MonitorXcode` attach + log tap succeeds. ERROR: - When a user-launched Xcode is already running, MonitorXcode() calls Popen with SOURCEKIT_LOGGING=1 … Xcode. The second Xcode process exits immediately (macOS single-instances the app and just activates the existing one)
-- [ ] **Re-sync submodules against latest heads** — after upstream merges, run `git submodule update --init --recursive` and bump pins in a dedicated commit.
 - [ ] **Settings / preferences refactor** — continue consolidating `ConfigStore` as the single source of truth; migrate any remaining `UserDefaults` direct reads in the backend (`MonitorXcode`, `NextCompiler`, `FrontendServer`).
 - [ ] **Logging + error surfacing improvements** — surface last compile error in the status menu; ring-buffer truncation indicator in the console; level filter persistence.
 - [ ] **README / docs update for the 2.0 flow** — document the SwiftUI entry, ConfigStore, and the in-app Console.
 - [ ] **Smoke-test matrix** — Xcode 15.x, 16.x, 26.x; macOS 14 / 15. Capture screenshots per matrix.
-
-## Current branch
-
-`maatheusgois-dd/2.0_overhaul-ui` off `maatheusgois-dd/2.0_overhaul`.
 
 Clean build: `xcodebuild -project App/InjectionNext.xcodeproj -scheme InjectionNext clean build` → `BUILD SUCCEEDED` on Xcode 26.3.


### PR DESCRIPTION
## Summary

Fixes the red menu icon when `InjectionNext.app` is launched while an Xcode the user started themselves is already running.

### Bug

`MonitorXcode()` calls `Popen(cmd: "… SOURCEKIT_LOGGING=1 Xcode …")`. macOS single-instances `Xcode.app`, so when one is already running the shell's child exits immediately while the OS just activates the existing process. Result: EOF'd stdout, no SourceKit log stream, and the first client connect or inject trips `setMenuIcon(.error)` → persistent red icon until a real compile event flips it.

### Fix

`AppDelegate.runXcode(_:)` now:

- detects a pre-existing Xcode that was **not** spawned by us (no `RUNNING_VIA_INJECTION_NEXT=1` env marker — already exported by `MonitorXcode.init`),
- prompts the user to quit-and-relaunch (`NSAlert`),
- terminates it and waits for it to exit (bounded 15s `RunLoop` poll),
- then proceeds through `MonitorXcode()` so the log-parsing path actually owns the Xcode process.

Added helpers: `externalRunningXcode()`, `confirmQuitExternalXcode()`, `waitForXcodeToExit(_:)`. No new env var, no new setting. Env is read via `ps eww -p <pid>`, which on modern macOS only returns env for processes owned by the current user — exactly what we need.

### Notes / assumptions

- Went with **quit-and-relaunch** (not silent kill, not warn-only). If you'd rather have a `ConfigStore` toggle to suppress the alert, happy to follow up.
- Currently only applied to `runXcode`. `applicationDidFinishLaunching` auto-launch (`MonitorXcode(args: " '\(project)'")` when `Defaults.projectPath` is set) still has the old behaviour. Easy to extend if you want the same guard there — flagging rather than sneaking it in.

### Test plan

- [x] `xcodebuild clean build` on Xcode 26.3 → BUILD SUCCEEDED.
- [ ] Launch `InjectionNext.app` with no Xcode running → click "Launch Xcode" → verify MonitorXcode attaches, icon goes blue/green on compile.
- [ ] User-launch Xcode first, then open `InjectionNext.app`, then click "Launch Xcode" → confirm alert appears, accept → Xcode quits, relaunches under InjectionNext, icon stays idle (no red).
- [ ] Same scenario, press Cancel → Xcode stays running, icon stays idle (no MonitorXcode spawned, no red).

Made with [Cursor](https://cursor.com)