### PR TITLE
chore: add Makefile for build/install/run workflow

### DIFF
--- a/App/Makefile
+++ b/App/Makefile
@@ -1,0 +1,64 @@
+# InjectionNext — Makefile
+#
+# Lives next to InjectionNext.xcodeproj. Run from App/ (or via
+# `make -C App <target>` from the repo root).
+
+XCODE_PROJECT ?= InjectionNext.xcodeproj
+XCODE_SCHEME  ?= InjectionNext
+XCODE_CONFIG  ?= Debug
+DERIVED_DATA  ?= build
+APP_NAME      ?= InjectionNext
+APP_PATH      := $(DERIVED_DATA)/Build/Products/$(XCODE_CONFIG)/$(APP_NAME).app
+
+.PHONY: all build-app run open clean kill help move-app sync
+
+all: build-app
+
+help:
+	@echo "Targets:"
+	@echo "  build-app   Build $(APP_NAME).app ($(XCODE_CONFIG))"
+	@echo "  run         Build then launch the app"
+	@echo "  open        Open the installed app"
+	@echo "  kill        Kill any running $(APP_NAME) process"
+	@echo "  sync        Pull latest + update submodules"
+	@echo "  clean       Remove derived data ($(DERIVED_DATA))"
+
+kill:
+	@pkill -x $(APP_NAME) 2>/dev/null || true
+	@sleep 0.2
+
+build-app: kill
+	@echo "==> Building $(APP_NAME).app ($(XCODE_CONFIG))..."
+	xcodebuild \
+		-project $(XCODE_PROJECT) \
+		-scheme $(XCODE_SCHEME) \
+		-configuration $(XCODE_CONFIG) \
+		-destination 'platform=macOS' \
+		-derivedDataPath $(DERIVED_DATA) \
+		build \
+		CODE_SIGN_IDENTITY="-" \
+		CODE_SIGNING_REQUIRED=NO \
+		CODE_SIGNING_ALLOWED=NO \
+		-quiet
+	@echo "==> Build complete: $(APP_PATH)"
+
+move-app: build-app kill
+	@echo "==> Installing to /Applications..."
+	@rm -rf /Applications/$(APP_NAME).app
+	@cp -R $(APP_PATH) /Applications/
+
+open: move-app
+	@echo "==> Opening $(APP_PATH)..."
+	@open /Applications/InjectionNext.app
+
+run: build-app open
+
+sync:
+	@echo "==> Pulling latest and syncing submodules..."
+	git pull
+	git submodule update --init --recursive
+	@echo "==> Done."
+
+clean:
+	@echo "==> Cleaning $(DERIVED_DATA)..."
+	@rm -rf $(DERIVED_DATA)


### PR DESCRIPTION
## Summary

Adds a top-level `Makefile` to streamline local development of the macOS app on the `2.0_overhaul` branch.

Targets:
- `build-app` – builds `InjectionNext.app` (Debug) via `xcodebuild` with ad-hoc signing.
- `run` – builds, installs to `/Applications`, and launches the app.
- `open` / `move-app` – install the built app to `/Applications` and open it.
- `kill` – kill any running `InjectionNext` process (used before build/install to avoid code-sign/launch races).
- `sync` – pull latest and update submodules (`DLKit`, `InjectionLite`).
- `clean` – remove derived data.

No source code changes. Purely a developer convenience file.

## Test Plan

- `make build-app` builds successfully against `App/InjectionNext.xcodeproj`.
- `make run` launches the freshly built `InjectionNext.app`.
- `make kill` terminates the running app cleanly.
- `make sync` pulls + updates submodules.

Made with [Cursor](https://cursor.com)