### PR TITLE
docs(todo): flesh out 2.0 Next section with fork-discovered items

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,12 +17,28 @@ Tracking the path from today's `2.0_overhaul` to a tagged `2.0.0`.
 ## Next
 
 - [ ] **Bump version to 2.0.0** — `MARKETING_VERSION`; tag after upstream merge.
-- [ ] **Fix red internal-Xcode icon when launching Xcode from the app (non log-parsing path)** — currently stays red until a compile event flips it; need to flip to idle/green once the `MonitorXcode` attach + log tap succeeds. ERROR: - When a user-launched Xcode is already running, MonitorXcode() calls Popen with SOURCEKIT_LOGGING=1 … Xcode. The second Xcode process exits immediately (macOS single-instances the app and just activates the existing one)
+- [ ] **Fix red internal-Xcode icon when launching Xcode from the app (non log-parsing path)** — currently stays red until a compile event flips it; need to flip to idle/green once the `MonitorXcode` attach + log tap succeeds. ERROR: - When a user-launched Xcode is already running, MonitorXcode() calls Popen with SOURCEKIT_LOGGING=1 … Xcode. The second Xcode process exits immediately (macOS single-instances the app and just activates the existing one).
 - [ ] **Re-sync submodules against latest heads** — after upstream merges, run `git submodule update --init --recursive` and bump pins in a dedicated commit.
 - [ ] **Settings / preferences refactor** — continue consolidating `ConfigStore` as the single source of truth; migrate any remaining `UserDefaults` direct reads in the backend (`MonitorXcode`, `NextCompiler`, `FrontendServer`).
 - [ ] **Logging + error surfacing improvements** — surface last compile error in the status menu; ring-buffer truncation indicator in the console; level filter persistence.
 - [ ] **README / docs update for the 2.0 flow** — document the SwiftUI entry, ConfigStore, and the in-app Console.
 - [ ] **Smoke-test matrix** — Xcode 15.x, 16.x, 26.x; macOS 14 / 15. Capture screenshots per matrix.
+
+### Hybrid / file-watcher
+
+- [ ] **Allow file-watcher injection while Xcode is running** — `InjectionHybrid.filesChanged(_:)` currently returns early with `guard MonitorXcode.runningXcode == nil else { return }`. Drop that gate so editors like Cursor / VSCode and Bazel-driven workflows can inject without quitting Xcode. Xcode-owned compiles still win via the existing `MonitorXcode.recompiler.canCompile` fast-path.
+- [ ] **Skip SDK filter in log-parsing recompiler when no client is connected** — `Recompiler.recompile(..., platformFilter: "SDKs/\(platform)")` uses `FrontendServer.clientPlatform`, which defaults to `"MacOSX"` until a device/sim connects. Editing an iOS file before first connect produces `grep SDKs/MacOSX` misses and `Log scanning failed` errors. Detect `InjectionServer.currentClients.isEmpty` and drop the `SDKs/...` filter so the most recent build log wins instead.
+- [ ] **Replace `DispatchQueue.main.sync` lock on `pendingFilesChanged` with `NSLock`** — the file-watcher debounce currently hops to the main queue just to mutate a shared array, which deadlocks when the main queue is already waiting on disk I/O inside the compile path. A plain `NSLock` (or `OSAllocatedUnfairLock`) around `pendingFilesChanged` is both correct and non-blocking.
+
+### Developer tooling
+
+- [ ] **Reuse already-running Xcode instead of spawning a duplicate process** — `AppDelegate.runXcode(_:)` unconditionally calls `MonitorXcode()`, which `Popen`-launches `Xcode.app`. macOS single-instances `Xcode.app`, so the second process activates the existing one and exits immediately, leaving `MonitorXcode.runningXcode` pointed at a dead pipe and the status icon stuck red. Detect a running Xcode via `NSRunningApplication` and attach to it (mirror lifecycle into the status icon, observe `NSWorkspace.didTerminateApplicationNotification`) rather than spawning.
+- [ ] **Top-level `Makefile` for local dev** — `build-app` / `run` / `open` / `kill` / `sync` / `clean` targets wrapping the `xcodebuild` invocation and `/Applications` install step, so contributors don't have to memorise the flags. Zero source impact.
+- [ ] **CI release workflow** — `.github/workflows/release.yml` that builds on tag push, codesigns / notarises (optional), attaches the `.app` to a GitHub Release, and surfaces `InjectionNext.dmg`. Pairs with the 2.0.0 tag.
+
+### Integrations / observability
+
+- [ ] **Injection event tracker for external consumers (MCP / AI agents)** — emit structured events (`detecting` / `compiled` / `injected` / `failed`) from `InjectionHybrid.filesChanged` and `Recompiler.inject` into an `ObservableObject` bus. Surface over the existing `ControlServer` (`mcp-server/index.js`) so editors can react to injection state in real time.
 
 ## Current branch
 


### PR DESCRIPTION
## Summary

Documentation-only change. Adds seven concrete backlog items to `TODO.md`'s `## Next` list, grouped into three subsections. All of them came up while running a `maatheusgois-dd` fork of `2.0_overhaul` against real iOS / Bazel codebases, and each one is a follow-up PR candidate.

No source code changes. This PR is purely to sync the roadmap with what's been discovered in the wild, so contributors have a shared backlog to pick from.

## New entries under `## Next`

### Hybrid / file-watcher

- **Allow file-watcher injection while Xcode is running** — drop the `guard MonitorXcode.runningXcode == nil else { return }` in `InjectionHybrid.filesChanged(_:)` so editors like Cursor / VSCode and Bazel-driven workflows can inject without quitting Xcode. Xcode-owned compiles still win via the existing `MonitorXcode.recompiler.canCompile` fast-path.
- **Skip SDK filter in log-parsing Recompiler when no client is connected** — `Recompiler.recompile(..., platformFilter: \"SDKs/\\(platform)\")` uses `FrontendServer.clientPlatform`, which defaults to `\"MacOSX\"` until a device/sim connects. Editing an iOS file before first connect produces `grep SDKs/MacOSX` misses and `Log scanning failed` errors. Detect `InjectionServer.currentClients.isEmpty` and drop the `SDKs/...` filter so the most recent build log wins.
- **Replace `DispatchQueue.main.sync` on `pendingFilesChanged` with an `NSLock`** — the debounce currently hops to the main queue to mutate a shared array, which can deadlock when the main queue is already waiting on disk I/O inside the compile path. An `NSLock` (or `OSAllocatedUnfairLock`) around `pendingFilesChanged` is both correct and non-blocking.

### Developer tooling

- **Reuse already-running Xcode instead of spawning a duplicate process** — `AppDelegate.runXcode(_:)` `Popen`-launches `Xcode.app`; macOS single-instances Xcode, so the second process activates the existing one and exits immediately, leaving `MonitorXcode.runningXcode` pointed at a dead pipe and the status icon stuck red. Detect via `NSRunningApplication`, attach to the running Xcode, observe `NSWorkspace.didTerminateApplicationNotification`. _(Implementation already in flight in #141.)_
- **Top-level `Makefile` for local dev** — `build-app` / `run` / `open` / `kill` / `sync` / `clean` targets wrapping `xcodebuild`. _(Implementation already in flight in #140.)_

### Integrations / observability

- **Injection event tracker for external consumers (MCP / AI agents)** — emit structured events (`detecting` / `compiled` / `injected` / `failed`) from `InjectionHybrid.filesChanged` and `Recompiler.inject` into an `ObservableObject` bus, surfaced over the existing `ControlServer` (`mcp-server/index.js`) so editors can react to injection state in real time.

## Test Plan

- [x] TODO.md renders cleanly in GitHub's preview.
- [x] No source changes; no build required. `git diff --stat` shows only `TODO.md`.

Made with [Cursor](https://cursor.com)