### PR TITLE
Fix Patch Compiler bypass on Xcode 26 (builtin-SwiftDriver invokes swiftc)

### DIFF
--- a/App/InjectionNext/FrontendServer.swift
+++ b/App/InjectionNext/FrontendServer.swift
@@ -247,8 +247,17 @@ extension AppDelegate {
     @IBAction func patchCompiler(_ sender: NSMenuItem) {
         let fm = FileManager.default
         do {
-            let linksToMove = ["swift", "swiftc", "swift-symbolgraph-extract",
-                               "swift-api-digester", "swift-cache-tool"]
+            // Tools that are not compile entry points: route directly to the
+            // original binary, the wrapper has nothing to do for them.
+            let linksToOriginal = ["swift", "swift-symbolgraph-extract",
+                                   "swift-api-digester", "swift-cache-tool"]
+            // Tools that ARE compile entry points and must hit the wrapper.
+            // Pre-Xcode 26, Xcode invoked swift-frontend directly; from
+            // Xcode 26 onward, builtin-SwiftDriver invokes swiftc instead.
+            // Routing only swiftc through the wrapper (rather than every
+            // multi-mode link) keeps overhead minimal.
+            let linksToWrapper = ["swiftc"]
+            let allLinks = linksToOriginal + linksToWrapper
             if updatePatchUnpatch() == .unpatched {
                 if !fm.fileExists(atPath: FrontendServer.patched),
                    let feeder = Bundle.main
@@ -272,22 +281,46 @@ extension AppDelegate {
                                     to: FrontendServer.patchedURL)
                     try fm.copyItem(at: feeder,
                                     to: FrontendServer.unpatchedURL)
-                    for binary in linksToMove {
+                    for binary in linksToOriginal {
                         let link = FrontendServer.binURL
                             .appendingPathComponent(binary)
                         try fm.removeItem(at: link)
                         symlink("swift-frontend.save", link.path)
+                    }
+                    for binary in linksToWrapper {
+                        let link = FrontendServer.binURL
+                            .appendingPathComponent(binary)
+                        try fm.removeItem(at: link)
+                        symlink("swift-frontend", link.path)
+                        // Wrapper resolves "$0.save"; create the matching
+                        // symlink so e.g. swiftc.save -> swift-frontend.save.
+                        let saveLink = FrontendServer.binURL
+                            .appendingPathComponent(binary + ".save")
+                        if fm.fileExists(atPath: saveLink.path) ||
+                            (try? fm.destinationOfSymbolicLink(
+                                atPath: saveLink.path)) != nil {
+                            try? fm.removeItem(at: saveLink)
+                        }
+                        symlink("swift-frontend.save", saveLink.path)
                     }
                 }
             } else if fm.fileExists(atPath: FrontendServer.patched) {
                 try? fm.removeItem(at: FrontendServer.unpatchedURL)
                 try fm.moveItem(at: FrontendServer.patchedURL,
                                 to: FrontendServer.unpatchedURL)
-                for binary in linksToMove {
+                for binary in allLinks {
                     let link = FrontendServer.binURL
                         .appendingPathComponent(binary)
                     try fm.removeItem(at: link)
                     symlink("swift-frontend", link.path)
+                }
+                for binary in linksToWrapper {
+                    let saveLink = FrontendServer.binURL
+                        .appendingPathComponent(binary + ".save")
+                    if (try? fm.destinationOfSymbolicLink(
+                            atPath: saveLink.path)) != nil {
+                        try? fm.removeItem(at: saveLink)
+                    }
                 }
                 FrontendServer.loggedFrontend = nil
             }

--- a/App/InjectionNext/swift-frontend.sh
+++ b/App/InjectionNext/swift-frontend.sh
@@ -5,8 +5,35 @@
 #
 #  Created by John Holdsworth on 23/02/2025.
 #  Copyright © 2025 John Holdsworth. All rights reserved.
+#
+#  Compiler interceptor wrapper. Installed in place of swift-frontend (and,
+#  on Xcode 26+, in place of swiftc) so that builtin-SwiftDriver compile
+#  invocations route through here. Runs the original binary preserving
+#  argv[0] (so the multi-mode swift binary picks the right tool) and, on
+#  successful compile invocations, feeds the captured command line to
+#  InjectionNext.app for later use as a recompile template.
 
 FRONTEND="$0"
-"$FRONTEND.save" "$@" &&
-if [ "$2" = "-c" ]; then "/Applications/InjectionNext.app/Contents/Resources/feedcommands" \
-    "2.0" "$(/usr/bin/env)" "$FRONTEND.save" "$@" >>/tmp/feedcommands.log 2>&1 & fi
+SAVE="$FRONTEND.save"
+
+# Run the real binary with argv[0] preserved. The Swift toolchain ships a
+# single multi-mode binary (swift-frontend / swiftc / swift / etc.) and
+# dispatches by argv[0] basename. Without -a here, when this wrapper is
+# installed at swiftc the binary would see itself as "swiftc.save" and the
+# dispatch would fall through to the wrong mode.
+( exec -a "$FRONTEND" "$SAVE" "$@" )
+RC=$?
+
+# Only feed the command if the real compile succeeded and this looks like a
+# per-file frontend compile. $2="-c" matches both legacy
+# `swift-frontend -frontend -c ...` and Xcode 26 `swiftc -frontend -c ...`.
+if [ $RC -eq 0 ] && [ "$2" = "-c" ]; then
+    # Always report the canonical original binary path to feedcommands so
+    # downstream cache entries are stable regardless of which symlink hit
+    # the wrapper.
+    CANONICAL="$(dirname "$FRONTEND")/swift-frontend.save"
+    "/Applications/InjectionNext.app/Contents/Resources/feedcommands" \
+        "2.0" "$(/usr/bin/env)" "$CANONICAL" "$@" >>/tmp/feedcommands.log 2>&1 &
+fi
+
+exit $RC


### PR DESCRIPTION
## Summary

On Xcode 26.3, `Patch Compiler` no longer captures any compile commands during a `xcodebuild` CLI build, so `/tmp/InjectionNext_iPhoneSimulator_builds.json.gz` never updates and saves of new files produce `Could not locate command for X.swift`. The wrapper is installed correctly; it is simply never executed.

Root cause: `patchCompiler` in `App/InjectionNext/FrontendServer.swift` repoints `swiftc → swift-frontend.save`, alongside `swift`, `swift-api-digester`, etc. That was correct on older Xcode where Xcode invoked `swift-frontend` directly. From Xcode 26, `builtin-SwiftDriver` invokes `swiftc` instead — and the `swiftc → swift-frontend.save` symlink resolves straight to the original binary, bypassing the wrapper.

Verified empirically on Xcode 26.3 with `EMIT_FRONTEND_COMMAND_LINES=YES`, `COMPILATION_CACHE_ENABLE_CACHING=NO`, `CLANG_CACHE_FINE_GRAINED_OUTPUTS=NO` set:
- 513 `swift-frontend` lines emitted to stdout
- `swift-frontend.save` subprocesses observed in `ps aux`, parented by `xcodebuild`/build service (not `bash`)
- `feedcommands.log` stayed at 0 bytes throughout
- `json.gz` mtime did not advance

## Fix

`App/InjectionNext/FrontendServer.swift` — split the previous `linksToMove` array:

- `linksToOriginal` (`swift`, `swift-symbolgraph-extract`, `swift-api-digester`, `swift-cache-tool`): not compile entry points, keep pointing at `swift-frontend.save`.
- `linksToWrapper` (`swiftc`): symlink to `swift-frontend` (the wrapper), and create a companion `swiftc.save → swift-frontend.save` so the wrapper's `"$0.save"` resolution still finds the original binary. Cleaned up on unpatch.

`App/InjectionNext/swift-frontend.sh`:

- Run the real binary via `( exec -a "$FRONTEND" "$SAVE" "$@" )` so `argv[0]` is preserved. The toolchain ships a single multi-mode binary that dispatches by `argv[0]` basename; without `-a` it would see itself as `swiftc.save` when invoked through the new path.
- Always report the canonical `swift-frontend.save` path to `feedcommands` (rather than `swiftc.save`), so `loggedFrontend` and downstream cache keys stay stable regardless of which entry point hit the wrapper.
- Retain the `[ "$2" = "-c" ]` filter — it matches both legacy `swift-frontend -frontend -c …` and Xcode 26 `swiftc -frontend -c …`.

The "synchronized folders / `PBXFileSystemSynchronizedRootGroup`" symptom often reported alongside this on Xcode 16+ projects is a downstream effect of the bypass: once the wrapper fires, Xcode's own `-filelist` argument already correctly enumerates source files under synchronized roots, so the existing `CompilationArgParser` handles them without additional changes.

## Scope of the change

- 2 files, +67/-7 lines.
- No protocol change to `feedcommands` (still receives `version, env, frontendPath, …args`, with `frontendPath` ending in `.save`).
- Pre-Xcode-26 toolchains are unaffected: `swift-frontend` invocations still hit the wrapper exactly as before; the only added path is `swiftc → wrapper → exec -a`.

## Test plan

- [x] Builds clean: `xcodebuild -scheme InjectionNext -configuration Debug` → `BUILD SUCCEEDED`.
- [x] `bash -n swift-frontend.sh` passes; verified `exec -a "$0" /path/to/swiftc.save` preserves `argv[0]` for a real binary (test C program prints `ARGV0=/path/to/swiftc`).
- [ ] Manual: Patch Compiler on Xcode 26.3, run `xcodebuild` clean build with the three documented flags, verify `feedcommands.log` grows and `json.gz` mtime advances.
- [ ] Manual: Edit a Swift file, save, verify `/tmp/injectionNext_*.o` is produced and `Inject` reports the patch.
- [ ] Manual: Unpatch Compiler restores original symlinks and removes `swiftc.save`.

## Related

- Discussion / repro doc on user side: brief from the reporter referencing CravingBuster (Reframe) workspace, Xcode 26.3, sim iPhone 17 / iOS 26.4. Happy to dogfood patch candidates against that workspace.